### PR TITLE
Add support for multiple IP subnets; dynamically update IP watched on…

### DIFF
--- a/src/Configuration/Application.cs
+++ b/src/Configuration/Application.cs
@@ -8,7 +8,8 @@ namespace RtcCallMonitor.Configuration
 {
     public class Application
     {
-        public string LocalNetwork { get; set; }
+        public string[] LocalNetwork { get; set; }
+        public int DelayMs { get; set; }
         public string CallStartWebhook { get; set; }
         public string CallEndWebhook { get; set; }
     }

--- a/src/IPHeader.cs
+++ b/src/IPHeader.cs
@@ -19,9 +19,9 @@ namespace RtcCallMonitor
             try
             {
                 //Create MemoryStream out of the received bytes
-                MemoryStream memoryStream = new MemoryStream(buffer, 0, length);
+                using MemoryStream memoryStream = new MemoryStream(buffer, 0, length);
                 //Next we create a BinaryReader out of the MemoryStream
-                BinaryReader binaryReader = new BinaryReader(memoryStream);
+                using BinaryReader binaryReader = new BinaryReader(memoryStream);
 
                 //The first eight bits of the IP header contain the version and
                 //header length so we read them

--- a/src/Worker.cs
+++ b/src/Worker.cs
@@ -38,7 +38,7 @@ namespace RtcCallMonitor
             {
                 try
                 {
-                    await Task.Delay(1000, stoppingToken);
+                    await Task.Delay(_appConfig.Value.DelayMs, stoppingToken);
                     _monitor.CheckStats();
                 }
                 catch (Exception e)

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -8,9 +8,12 @@
     }
   },
   "Application": {
-    "LocalNetwork": "192.168.1.0/24",
+    "LocalNetwork": [
+      "192.168.1.0/24"
+    ],
     "CallStartWebhook": "",
-    "CallEndWebhook": ""
+    "CallEndWebhook": "",
+    "DelayMs": 2000
   },
   "Provider": {
     "KnownNetworks": {


### PR DESCRIPTION
… network state change

While working, connecting to a work VPN generally changes your current IP address. This update allows defining multiple IP ranges and also handles detecting the IP address on network state changes.

I also made the delay configurable - I was seeing call status flips a lot when I was still on a call. I also used the same setting for a delay on network state change - it takes a couple seconds for the new IP to be detectable.

I haven't tested other use cases, but this change could be useful on networks where wired/wireless clients operate on different IP ranges.